### PR TITLE
Ignore duplicate guesses

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -299,7 +299,9 @@ def on_message(message, client):
 def process_guess(guess):
     global whose_turn, num_guesses
     condolences = ["Oh, dear.\n", "That's too bad.\n", "I feel for you.\n", "What were you thinking?\n", "Uh... what?\n", "Maybe you'll do better next time.\n", "Seriously?\n", "I hope you feel okay about that.\n", "When will you learn?\n"]
-    if guess in board[1]:
+    if guess.lower() in guessed:
+        room.send_message("%s has already been guessed." % (guess.upper()))
+    elif guess in board[1]:
         guessed.append( guess.lower() )
         message = guess
         new_turn = False


### PR DESCRIPTION
If an already-identified agent is guessed a second time, Shiro will treat the guess like any other rather than informing the guesser and otherwise ignoring the guess. This may well be intended behavior to punish not paying attention, but there was a [request](https://chat.stackexchange.com/transcript/message/52409407#52409407) in the room today.

I have not tested this three-line change, but it had better work.